### PR TITLE
Updating google login, closes #99

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gift-manager",
-  "version": "1.0.0",
+  "version": "1.0.1-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "metascraper-url": "^4.7.0",
     "morgan": "^1.8.1",
     "passport": "^0.3.2",
-    "passport-google-oauth": "^1.0.0",
+    "passport-google-oauth20": "^1.0.0",
     "passport-twitter": "^1.0.4",
     "pg": "^6.1.2",
     "pg-hstore": "^2.3.2",

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -1,7 +1,7 @@
 const Op = require('sequelize').Op
 const passport = require('passport')
 const router = require('express').Router()
-const GoogleStrategy = require('passport-google-oauth').OAuth2Strategy
+const GoogleStrategy = require('passport-google-oauth20').Strategy
 const {User} = require('../db/models')
 const newUserSeed = require('../../script/new-user-seed')
 module.exports = router
@@ -14,7 +14,8 @@ if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
   const googleConfig = {
     clientID: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    callbackURL: process.env.GOOGLE_CALLBACK
+    callbackURL: process.env.GOOGLE_CALLBACK,
+    userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo'
   }
 
   const strategy = new GoogleStrategy(


### PR DESCRIPTION
This update is based on the solution [here](https://stackoverflow.com/questions/53887010/is-the-google-strategy-in-passport-js-deprecated-with-the-end-of-google/54112673#54112673) which adds the Passport google strategy option of `userProfileURL`:

`userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo'`

I've also changed the strategy from `passport-google-oauth` to `passport-google-oauth20` although it seems like either will still work as long as the new user profile url is provided.